### PR TITLE
fix(secondary_source): Error: Reference to undeclared resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -427,7 +427,7 @@ resource "aws_codebuild_project" "default" {
     }
   }
 
-  dynamic "secondary_sources" {
+  dynamic "secondary_source" {
     for_each = var.secondary_sources
     content {
       git_clone_depth     = secondary_source.value.git_clone_depth


### PR DESCRIPTION
## what
* Fixes type - name of the variable used for provision "secondary sources"

## why
* Failing with error:
```
╷
│ Error: Reference to undeclared resource
│ 
│   on .terraform/modules/cicd.pr_build/main.tf line 438, in resource "aws_codebuild_project" "default":
│  438:       report_build_status = secondary_source.value.report_build_status
│ 
│ A managed resource "secondary_source" "value" has not been declared in module.cicd.module.pr_build.
