### PR TITLE
fix: required random provider version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 2.1"
+      version = ">= 3.4"
     }
   }
 }


### PR DESCRIPTION

[number](https://registry.terraform.io/providers/hashicorp/random/3.4.0/docs/resources/string#number) (Boolean, Deprecated) Include numeric characters in the result. Default value is true. NOTE: This is deprecated, use numeric instead.
[numeric](https://registry.terraform.io/providers/hashicorp/random/3.4.0/docs/resources/string#numeric) (Boolean) Include numeric characters in the result. Default value is true.