### PR TITLE
Feat/v4

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/main.tf
+++ b/main.tf
@@ -309,9 +309,9 @@ resource "aws_codebuild_project" "default" {
     content {
       combine_artifacts = "true"
       service_role      = join("", aws_iam_role.default.*.arn)
-      timeout_in_mins   = 20
+      timeout_in_mins   = 30
       restrictions {
-        # compute_types_allowed = ["BUILD_GENERAL1_SMALL"]
+        // todo, tune based on needs
         maximum_builds_allowed = 100
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -302,18 +302,18 @@ resource "aws_codebuild_project" "default" {
     location = var.artifact_location
   }
 
-  
+
   dynamic "build_batch_config" {
-     for_each = var.concurrent_build_limit == 1 ? [] : [1]
-      content {
-        combine_artifacts = "true"
-        service_role      = join("", aws_iam_role.default.*.arn)
-        timeout_in_mins   = 20
-        restrictions {
-          # compute_types_allowed = ["BUILD_GENERAL1_SMALL"]
-          maximum_builds_allowed = 100
-        }
+    for_each = var.concurrent_build_limit == 1 ? [] : [1]
+    content {
+      combine_artifacts = "true"
+      service_role      = join("", aws_iam_role.default.*.arn)
+      timeout_in_mins   = 20
+      restrictions {
+        # compute_types_allowed = ["BUILD_GENERAL1_SMALL"]
+        maximum_builds_allowed = 100
       }
+    }
   }
 
   # Since the output type is restricted to S3 by the provider (this appears to

--- a/main.tf
+++ b/main.tf
@@ -140,6 +140,7 @@ data "aws_iam_policy_document" "permissions" {
 
     actions = compact(concat([
       "codecommit:GitPull",
+      "ecr:BatchCheckLayerAvailability",
       "ecr:CompleteLayerUpload",
       "ecr:GetAuthorizationToken",
       "ecr:InitiateLayerUpload",

--- a/main.tf
+++ b/main.tf
@@ -419,15 +419,15 @@ resource "aws_codebuild_project" "default" {
   dynamic "secondary_sources" {
     for_each = var.secondary_sources
     content {
-      git_clone_depth     = secondary_source.value.git_clone_depth
-      location            = secondary_source.value.location
-      source_identifier   = secondary_source.value.source_identifier
-      type                = secondary_source.value.type
-      insecure_ssl        = secondary_source.value.insecure_ssl
-      report_build_status = secondary_source.value.report_build_status
+      git_clone_depth     = secondary_sources.value.git_clone_depth
+      location            = secondary_sources.value.location
+      source_identifier   = secondary_sources.value.source_identifier
+      type                = secondary_sources.value.type
+      insecure_ssl        = secondary_sources.value.insecure_ssl
+      report_build_status = secondary_sources.value.report_build_status
 
       git_submodules_config {
-        fetch_submodules = secondary_source.value.fetch_submodules
+        fetch_submodules = secondary_sources.value.fetch_submodules
       }
     }
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,12 +20,12 @@ output "role_arn" {
 
 output "cache_bucket_name" {
   description = "Cache S3 bucket name"
-  value       = module.this.enabled && local.s3_cache_enabled ? join("", aws_s3_bucket.cache_bucket.*.bucket) : "UNSET"
+  value       = module.this.enabled && local.s3_cache_enabled ? join("", module.cache_bucket.*.bucket_id) : "UNSET"
 }
 
 output "cache_bucket_arn" {
   description = "Cache S3 bucket ARN"
-  value       = module.this.enabled && local.s3_cache_enabled ? join("", aws_s3_bucket.cache_bucket.*.arn) : "UNSET"
+  value       = module.this.enabled && local.s3_cache_enabled ? join("", module.cache_bucket.*.bucket_arn) : "UNSET"
 }
 
 output "badge_url" {

--- a/variables.tf
+++ b/variables.tf
@@ -26,7 +26,7 @@ variable "description" {
 
 variable "concurrent_build_limit" {
   type        = number
-  default     = null
+  default     = 1
   description = "Specify a maximum number of concurrent builds for the project. The value specified must be greater than 0 and less than the account concurrent running builds limit."
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,14 +1,14 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.0.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 4.9.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.4"
+      version = ">= 2.1"
     }
   }
 }


### PR DESCRIPTION
## what
* Extend codebuild with bath builds logic and roles

## why
* Batch builds are used to parallelize work on aws codebuilds and pipelines, and its needed to split the builds from our repo

## references
* fork changes from https://github.com/cloudposse/terraform-aws-codebuild

